### PR TITLE
Support modern package managers and skip fixing yarn.lock if package.json has conflicts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,15 +50,15 @@ runs:
 
     - name: Install package manager
       shell: bash
-      if: ${{ steps.detect-package-manager.PACKAGE_MANAGER != '' }}
+      if: ${{ steps.detect-package-manager.outputs.PACKAGE_MANAGER != '' }}
       run: |
-        corepack enable ${{ steps.detect-package-manager.PACKAGE_MANAGER }}
+        corepack enable ${{ steps.detect-package-manager.outputs.PACKAGE_MANAGER }}
 
     - name: Setup node
       uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc
-        cache: ${{ steps.detect-package-manager.PACKAGE_MANAGER != '' && steps.detect-package-manager.PACKAGE_MANAGER || 'yarn' }}
+        cache: ${{ steps.detect-package-manager.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager.outputs.PACKAGE_MANAGER || 'yarn' }}
         cache-dependency-path: yarn.lock
 
     - name: Fetch Bullet Train Starter Repo
@@ -188,9 +188,9 @@ runs:
 
     - name: Install package manager
       shell: bash
-      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' && steps.detect-package-manager-redux.PACKAGE_MANAGER != '' }}
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != '' }}
       run: |
-        corepack enable ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER }}
+        corepack enable ${{ steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER }}
 
     # After merging the latest changes from the start repo the node version might have changed. We
     # run setup-node again to ensure that we have the right version.
@@ -200,7 +200,7 @@ runs:
       if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' }}
       with:
         node-version-file: .nvmrc
-        cache: ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.PACKAGE_MANAGER || 'yarn' }}
+        cache: ${{ steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER || 'yarn' }}
         cache-dependency-path: yarn.lock
 
     # Now yarn.lock should be de-conflicted

--- a/action.yml
+++ b/action.yml
@@ -42,11 +42,23 @@ runs:
       with:
         bundler-cache: true
 
+    - name: Detect package manager
+      id: detect-package-manager
+      shell: bash
+      run: |
+        node -p "'PACKAGE_MANAGER='+require('./package.json').packageManager?.split?.('@')?.[0]" >> "$GITHUB_OUTPUT"
+
+    - name: Install package manager
+      shell: bash
+      if: ${{ steps.detect-package-manager.PACKAGE_MANAGER != '' }}
+      run: |
+        corepack enable ${{ steps.detect-package-manager.PACKAGE_MANAGER }}
+
     - name: Setup node
       uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc
-        cache: 'yarn'
+        cache: ${{ steps.detect-package-manager.PACKAGE_MANAGER != '' && steps.detect-package-manager.PACKAGE_MANAGER || 'yarn' }}
         cache-dependency-path: yarn.lock
 
     - name: Fetch Bullet Train Starter Repo
@@ -160,6 +172,18 @@ runs:
       run: |
         git checkout HEAD -- yarn.lock
 
+    - name: Detect package manager
+      id: detect-package-manager-redux
+      shell: bash
+      run: |
+        node -p "'PACKAGE_MANAGER='+require('./package.json').packageManager?.split?.('@')?.[0]" >> "$GITHUB_OUTPUT"
+
+    - name: Install package manager
+      shell: bash
+      if: ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER != '' }}
+      run: |
+        corepack enable ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER }}
+
     # After merging the latest changes from the start repo the node version might have changed. We
     # run setup-node again to ensure that we have the right version.
     - name: Setup node
@@ -167,7 +191,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc
-        cache: 'yarn'
+        cache: ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.PACKAGE_MANAGER || 'yarn' }}
         cache-dependency-path: yarn.lock
 
     # Now yarn.lock should be de-conflicted

--- a/action.yml
+++ b/action.yml
@@ -157,9 +157,16 @@ runs:
     #
     ####################################################################################################
 
+    - name: Check for conflicts in package.json
+      id: package-json-conflicts
+      shell: bash
+      run: |
+        echo "PACKAGE_JSON_CONFLICT=$(git status --porcelain package.json | grep '^UU')" >> $GITHUB_OUTPUT
+
     - name: Check for conflicts in yarn.lock
       id: yarn-lock-conflicts
       shell: bash
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' }}
       run: |
         echo "YARN_LOCK_CONFLICT=$(git status --porcelain yarn.lock | grep '^UU')" >> $GITHUB_OUTPUT
 
@@ -168,19 +175,20 @@ runs:
     # and then run `bundle install` to ensure that it's in sync with yarn
     - name: Fix yarn.lock - Part 1
       shell: bash
-      if: ${{ steps.yarn-lock-conflicts.outputs.YARN_LOCK_CONFLICT != '' }}
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' && steps.yarn-lock-conflicts.outputs.YARN_LOCK_CONFLICT != '' }}
       run: |
         git checkout HEAD -- yarn.lock
 
     - name: Detect package manager
       id: detect-package-manager-redux
       shell: bash
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' }}
       run: |
         node -p "'PACKAGE_MANAGER='+require('./package.json').packageManager?.split?.('@')?.[0]" >> "$GITHUB_OUTPUT"
 
     - name: Install package manager
       shell: bash
-      if: ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER != '' }}
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' && steps.detect-package-manager-redux.PACKAGE_MANAGER != '' }}
       run: |
         corepack enable ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER }}
 
@@ -189,6 +197,7 @@ runs:
     - name: Setup node
       #continue-on-error: true # It will complain about the lock file being out of date, but we don't want to stop here
       uses: actions/setup-node@v3
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' }}
       with:
         node-version-file: .nvmrc
         cache: ${{ steps.detect-package-manager-redux.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.PACKAGE_MANAGER || 'yarn' }}
@@ -197,7 +206,7 @@ runs:
     # Now yarn.lock should be de-conflicted
     - name: Fix yarn.lock - Part 2
       shell: bash
-      if: ${{ steps.yarn-lock-conflicts.outputs.YARN_LOCK_CONFLICT != '' }}
+      if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' && steps.yarn-lock-conflicts.outputs.YARN_LOCK_CONFLICT != '' }}
       run: |
         yarn install --no-immutable
         # Now we add the changes


### PR DESCRIPTION
This PR addresses two issues:

1. Enables support for modern package managers such as `yarn@v4` or `pnpm` by detecting the `packageManager` entry in `package.json` and enabling corepack if the entry is found.
2. Skips trying to fix conflicts in `yarn.lock` if there are conflicts found in `package.json` since the yarn commands will fail due to the conflict making `package.json` an invalid json file.

Happy to split this up into two PRs if that is preferred.