### PR TITLE
don't cache node dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,8 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
-        cache: ${{ steps.detect-package-manager.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager.outputs.PACKAGE_MANAGER != 'undefined' && steps.detect-package-manager.outputs.PACKAGE_MANAGER || 'yarn' }}
-        cache-dependency-path: yarn.lock
+        #cache: ${{ steps.detect-package-manager.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager.outputs.PACKAGE_MANAGER != 'undefined' && steps.detect-package-manager.outputs.PACKAGE_MANAGER || 'yarn' }}
+        #cache-dependency-path: yarn.lock
 
     - name: Fetch Bullet Train Starter Repo
       shell: bash
@@ -200,8 +200,8 @@ runs:
       if: ${{ steps.package-json-conflicts.outputs.PACKAGE_JSON_CONFLICT == '' }}
       with:
         node-version-file: .nvmrc
-        cache: ${{ steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != 'undefined' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER || 'yarn' }}
-        cache-dependency-path: yarn.lock
+        #cache: ${{ steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != '' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER != 'undefined' && steps.detect-package-manager-redux.outputs.PACKAGE_MANAGER || 'yarn' }}
+        #cache-dependency-path: yarn.lock
 
     # Now yarn.lock should be de-conflicted
     - name: Fix yarn.lock - Part 2


### PR DESCRIPTION
Sometimes caching around node dependencies will cause this action to fail with an error like this:

![CleanShot 2024-07-01 at 14 37 20](https://github.com/bullet-train-co/create-upgrade-pr/assets/58702/e531e15d-8e2d-41d4-85dd-a53065a8e3be)

I'm not sure why it only happens some of the time.

I'm also not sure that we really benefit from caching node dependencies in this action, so for now I'm just disabling the cache.